### PR TITLE
Update for SDK4

### DIFF
--- a/ch2driver/pytpcc/drivers/nestcollectionsdriver.py
+++ b/ch2driver/pytpcc/drivers/nestcollectionsdriver.py
@@ -51,8 +51,7 @@ from datetime import timedelta
 import sys
 import traceback
 import couchbase.collection
-from couchbase.cluster import Cluster
-from couchbase.options import ClusterOptions, ClusterTimeoutOptions
+from couchbase.cluster import Cluster, ClusterOptions, ClusterTimeoutOptions
 from couchbase.auth import PasswordAuthenticator
 
 QUERY_URL = "127.0.0.1:8093"


### PR DESCRIPTION
PR to add Salim's fix for running CH2 against a Capella cluster with Python SDK 4.x